### PR TITLE
Fix encode and decode typespecs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/cobs.ex
+++ b/lib/cobs.ex
@@ -11,7 +11,7 @@ defmodule Cobs do
       {:ok, <<0x03, 0x01, 0x02, 0x02, 0x03>>}
   """
 
-  @spec encode(binary()) :: {:ok, binary()} | {:error | String.t}
+  @spec encode(binary()) :: {:ok, binary()} | {:error | String.t()}
   def encode(binary) do
     if byte_size(binary) <= 254 do
       {:ok, do_encode(<<>>, <<>>, binary)}
@@ -24,11 +24,13 @@ defmodule Cobs do
   defp do_encode(head, block, tail)
 
   defp do_encode(head, block, <<>>),
-       do: head <> <<byte_size(block) + 1>> <> block
-  defp do_encode(head, block, <<0, tail :: binary>>),
-       do: do_encode(head <> <<byte_size(block) + 1>> <> block, <<>>, tail)
-  defp do_encode(head, block, <<val, tail :: binary>>),
-       do: do_encode(head, block <> <<val>>, tail)
+    do: head <> <<byte_size(block) + 1>> <> block
+
+  defp do_encode(head, block, <<0, tail::binary>>),
+    do: do_encode(head <> <<byte_size(block) + 1>> <> block, <<>>, tail)
+
+  defp do_encode(head, block, <<val, tail::binary>>),
+    do: do_encode(head, block <> <<val>>, tail)
 
   @doc """
   Encode a binary (with `0` bytes) into a COBS encoded binary (without `0` bytes).
@@ -44,8 +46,10 @@ defmodule Cobs do
     case encode(binary) do
       {:ok, result} ->
         result
+
       {:error, message} ->
         raise ArgumentError, message
+
       _ ->
         raise ArgumentError
     end
@@ -59,7 +63,7 @@ defmodule Cobs do
       iex> Cobs.decode(<<0x03, 0x01, 0x02, 0x02, 0x03>>)
       {:ok, <<0x01, 0x02, 0x00, 0x03>>}
   """
-  @spec decode(binary()) :: {:ok, binary()} | {:error | String.t}
+  @spec decode(binary()) :: {:ok, binary()} | {:error | String.t()}
   def decode(binary)
 
   def decode(binary) do
@@ -73,12 +77,13 @@ defmodule Cobs do
     {:ok, head}
   end
 
-  defp do_decode(head, <<ohb, tail :: binary>>) do
+  defp do_decode(head, <<ohb, tail::binary>>) do
     block_length = ohb - 1
+
     if block_length > byte_size(tail) do
       {:error, "Offset byte specifies more bytes than available"}
     else
-      <<block :: binary - size(block_length), remaining :: binary>> = tail
+      <<block::binary-size(block_length), remaining::binary>> = tail
       new_head = if byte_size(remaining) > 0, do: head <> block <> <<0>>, else: head <> block
       do_decode(new_head, remaining)
     end
@@ -98,11 +103,12 @@ defmodule Cobs do
     case decode(binary) do
       {:ok, result} ->
         result
+
       {:error, message} ->
         raise ArgumentError, message
+
       _ ->
         raise ArgumentError
     end
   end
-
 end

--- a/lib/cobs.ex
+++ b/lib/cobs.ex
@@ -11,7 +11,7 @@ defmodule Cobs do
       {:ok, <<0x03, 0x01, 0x02, 0x02, 0x03>>}
   """
 
-  @spec encode(binary()) :: {:ok, binary()} | {:error | String.t()}
+  @spec encode(binary()) :: {:ok, binary()} | {:error, String.t()}
   def encode(binary) do
     if byte_size(binary) <= 254 do
       {:ok, do_encode(<<>>, <<>>, binary)}
@@ -49,9 +49,6 @@ defmodule Cobs do
 
       {:error, message} ->
         raise ArgumentError, message
-
-      _ ->
-        raise ArgumentError
     end
   end
 
@@ -63,14 +60,14 @@ defmodule Cobs do
       iex> Cobs.decode(<<0x03, 0x01, 0x02, 0x02, 0x03>>)
       {:ok, <<0x01, 0x02, 0x00, 0x03>>}
   """
-  @spec decode(binary()) :: {:ok, binary()} | {:error | String.t()}
+  @spec decode(binary()) :: {:ok, binary()} | {:error, String.t()}
   def decode(binary)
 
   def decode(binary) do
     do_decode(<<>>, binary)
   end
 
-  @spec do_decode(binary(), binary()) :: {:ok, binary()} | {:error | any()}
+  @spec do_decode(binary(), binary()) :: {:ok, binary()} | {:error, any()}
   defp do_decode(head, tail)
 
   defp do_decode(head, <<>>) do
@@ -106,9 +103,6 @@ defmodule Cobs do
 
       {:error, message} ->
         raise ArgumentError, message
-
-      _ ->
-        raise ArgumentError
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Cobs.Mixfile do
       app: :cobs,
       version: "0.2.0",
       elixir: "~> 1.5",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
       deps: deps(),
@@ -15,7 +15,7 @@ defmodule Cobs.Mixfile do
       homepage_url: "https://github.com/krodelin/cobs-elixir",
       docs: [
         main: "readme",
-        extras: ["README.md"],
+        extras: ["README.md"]
       ]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "33d7b70d87d45ed899180fb0413fb77c7c48843188516e15747e00fdecf572b6"},
 }

--- a/test/cobs_test.exs
+++ b/test/cobs_test.exs
@@ -2,43 +2,47 @@ defmodule CobsTest do
   use ExUnit.Case
   doctest Cobs
 
-  test "encode empty", do: assert Cobs.encode(<<>>) == {:ok, <<0x01>>}
-  test "decode empty", do: assert Cobs.decode(<<0x01>>) == {:ok, <<>>}
+  test "encode empty", do: assert(Cobs.encode(<<>>) == {:ok, <<0x01>>})
+  test "decode empty", do: assert(Cobs.decode(<<0x01>>) == {:ok, <<>>})
 
-  test "encode 1", do: assert Cobs.encode(<<0x01>>) == {:ok, <<0x02, 0x01>>}
-  test "decode 1", do: assert Cobs.decode(<<0x02, 0x01>>) == {:ok, <<0x01>>}
+  test "encode 1", do: assert(Cobs.encode(<<0x01>>) == {:ok, <<0x02, 0x01>>})
+  test "decode 1", do: assert(Cobs.decode(<<0x02, 0x01>>) == {:ok, <<0x01>>})
 
+  test "encode 0", do: assert(Cobs.encode(<<0x00>>) == {:ok, <<0x01, 0x01>>})
+  test "decode 0", do: assert(Cobs.decode(<<0x01, 0x01>>) == {:ok, <<0x00>>})
 
-  test "encode 0", do: assert Cobs.encode(<<0x00>>) == {:ok, <<0x01, 0x01>>}
-  test "decode 0", do: assert Cobs.decode(<<0x01, 0x01>>) == {:ok, <<0x00>>}
+  test "encode double 0", do: assert(Cobs.encode(<<0x00, 0x00>>) == {:ok, <<0x01, 0x01, 0x01>>})
+  test "decode double 0", do: assert(Cobs.decode(<<0x01, 0x01, 0x01>>) == {:ok, <<0x00, 0x00>>})
 
+  test "encode middle 0",
+    do: assert(Cobs.encode(<<0x01, 0x02, 0x00, 0x03>>) == {:ok, <<0x03, 0x01, 0x02, 0x02, 0x03>>})
 
-  test "encode double 0", do: assert Cobs.encode(<<0x00, 0x00>>) == {:ok, <<0x01, 0x01, 0x01>>}
-  test "decode double 0", do: assert Cobs.decode(<<0x01, 0x01, 0x01>>) == {:ok, <<0x00, 0x00>>}
+  test "decode middle 0",
+    do: assert(Cobs.decode(<<0x03, 0x01, 0x02, 0x02, 0x03>>) == {:ok, <<0x01, 0x02, 0x00, 0x03>>})
 
-  test "encode middle 0", do: assert Cobs.encode(<<0x01, 0x02, 0x00, 0x03>>) == {:ok, <<0x03, 0x01, 0x02, 0x02, 0x03>>}
-  test "decode middle 0", do: assert Cobs.decode(<<0x03, 0x01, 0x02, 0x02, 0x03>>) == {:ok, <<0x01, 0x02, 0x00, 0x03>>}
+  test "encode no 0",
+    do: assert(Cobs.encode(<<0x01, 0x02, 0x03, 0x04>>) == {:ok, <<0x05, 0x01, 0x02, 0x03, 0x04>>})
 
+  test "decode no 0",
+    do: assert(Cobs.decode(<<0x05, 0x01, 0x02, 0x03, 0x04>>) == {:ok, <<0x01, 0x02, 0x03, 0x04>>})
 
-  test "encode no 0", do: assert Cobs.encode(<<0x01, 0x02, 0x03, 0x04>>) == {:ok, <<0x05, 0x01, 0x02, 0x03, 0x04>>}
-  test "decode no 0", do: assert Cobs.decode(<<0x05, 0x01, 0x02, 0x03, 0x04>>) == {:ok, <<0x01, 0x02, 0x03, 0x04>>}
+  test "encode tripple 0",
+    do: assert(Cobs.encode(<<0x01, 0x00, 0x00, 0x00>>) == {:ok, <<0x02, 0x01, 0x01, 0x01, 0x01>>})
 
-
-  test "encode tripple 0", do: assert Cobs.encode(<<0x01, 0x00, 0x00, 0x00>>) == {:ok, <<0x02, 0x01, 0x01, 0x01, 0x01>>}
-  test "decode tripple 0", do: assert Cobs.decode(<<0x02, 0x01, 0x01, 0x01, 0x01>>) == {:ok, <<0x01, 0x00, 0x00, 0x00>>}
-
+  test "decode tripple 0",
+    do: assert(Cobs.decode(<<0x02, 0x01, 0x01, 0x01, 0x01>>) == {:ok, <<0x01, 0x00, 0x00, 0x00>>})
 
   test "encode too long" do
-    {return, _} = Cobs.encode(<<-1 :: unit(8) - size(254)>>)
+    {return, _} = Cobs.encode(<<-1::unit(8)-size(254)>>)
     assert return == :ok
-    {return, _} = Cobs.encode(<<-1 :: unit(8) - size(255)>>)
+    {return, _} = Cobs.encode(<<-1::unit(8)-size(255)>>)
     assert return == :error
-    {return, _} = Cobs.encode(<<-1 :: unit(8) - size(256)>>)
+    {return, _} = Cobs.encode(<<-1::unit(8)-size(256)>>)
     assert return == :error
   end
 
   test "encode too long exception" do
-    assert_raise ArgumentError, fn -> Cobs.encode! (<<-1 :: unit(8) - size(255)>>) end
+    assert_raise ArgumentError, fn -> Cobs.encode!(<<-1::unit(8)-size(255)>>) end
   end
 
   test "decode invalid" do
@@ -51,9 +55,8 @@ defmodule CobsTest do
   end
 
   defp invalid_data() do
-    {:ok, valid} = Cobs.encode(<<-1 :: unit(8) - size(253)>>)
+    {:ok, valid} = Cobs.encode(<<-1::unit(8)-size(253)>>)
     # The appended binary specifies ten remaining bytes although only one is present
     valid <> <<10, 0>>
   end
-
 end


### PR DESCRIPTION
The type specs for `encode` and `decode` had a type for the error return type. This was fixed and branches in the hard fail versions that would never be reached were removed.

This also adds formatting.exs configuration to ensure consistent formatting. I'm happy to tweak this if there is a preferred style you'd like to go for, but I'm not sure how much flexibility there is in the output. I could split it out too if you prefer. I've seen a lot of value in shared formatting configs though :-) 